### PR TITLE
Add snackbar notifications to intercept request (error/success) messages

### DIFF
--- a/client/src/app/components/login/login.component.ts
+++ b/client/src/app/components/login/login.component.ts
@@ -2,14 +2,12 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { LoginModules } from './login.module';
 import { AuthenticationService } from '../../services/authentication.service';
-import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
-import { PizzaPartyAnnotatedComponent } from '../../shared/components/snackbar.component';
 
 @Component({
   selector: 'login',
   standalone: true,
   providers: [AuthenticationService],
-  imports: [LoginModules, MatSnackBarModule],
+  imports: [LoginModules],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })
@@ -21,22 +19,16 @@ export class LoginComponent {
 
   constructor(
     private router: Router,
-    private authenticationService: AuthenticationService,
-    private _snackBar: MatSnackBar
+    private authenticationService: AuthenticationService
   ) {}
 
   public login = async (): Promise<void> => {
     const credentials = { username: this.username, password: this.password };
-    const response: any = await this.authenticationService.attemptLogin(
-      credentials
-    );
-    // console.log(response);
+    const response = await this.authenticationService.attemptLogin(credentials);
 
     // Authentication failed:
     if (response.error) {
-      console.error(response.message);
-      if (response.error.message) this.openSnackBar(response.error.message);
-      return;
+      console.log(response);
     }
 
     // We have a user, redirect to dasboard component:
@@ -45,27 +37,4 @@ export class LoginComponent {
       this.router.navigate(['/dashboard']);
     }
   };
-
-  public getSession = async (): Promise<void> => {
-    const response = await this.authenticationService.checkSession();
-    console.log(response);
-  };
-
-  public logout = async (): Promise<void> => {
-    const response = await this.authenticationService.logout();
-    console.log(response);
-  };
-
-  openSnackBar(message: string) {
-    this._snackBar.open(message, 'Close', {
-      horizontalPosition: 'right',
-      verticalPosition: 'top',
-      data: {
-        hello: 'hello from data snackbar',
-      },
-    });
-    // this._snackBar.openFromComponent(PizzaPartyAnnotatedComponent, {
-    //   duration: this.durationInSeconds * 1000,
-    // });
-  }
 }

--- a/client/src/app/components/login/login.component.ts
+++ b/client/src/app/components/login/login.component.ts
@@ -2,12 +2,14 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { LoginModules } from './login.module';
 import { AuthenticationService } from '../../services/authentication.service';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { PizzaPartyAnnotatedComponent } from '../../shared/components/snackbar.component';
 
 @Component({
   selector: 'login',
   standalone: true,
   providers: [AuthenticationService],
-  imports: [LoginModules],
+  imports: [LoginModules, MatSnackBarModule],
   templateUrl: './login.component.html',
   styleUrl: './login.component.scss',
 })
@@ -15,20 +17,25 @@ export class LoginComponent {
   public username: string = '';
   public password: string = '';
   public isPasswordHidden: boolean = true;
+  durationInSeconds = 5;
 
   constructor(
     private router: Router,
-    private authenticationService: AuthenticationService
+    private authenticationService: AuthenticationService,
+    private _snackBar: MatSnackBar
   ) {}
 
   public login = async (): Promise<void> => {
     const credentials = { username: this.username, password: this.password };
-    const response = await this.authenticationService.attemptLogin(credentials);
+    const response: any = await this.authenticationService.attemptLogin(
+      credentials
+    );
     // console.log(response);
 
     // Authentication failed:
     if (response.error) {
       console.error(response.message);
+      if (response.error.message) this.openSnackBar(response.error.message);
       return;
     }
 
@@ -48,4 +55,17 @@ export class LoginComponent {
     const response = await this.authenticationService.logout();
     console.log(response);
   };
+
+  openSnackBar(message: string) {
+    this._snackBar.open(message, 'Close', {
+      horizontalPosition: 'right',
+      verticalPosition: 'top',
+      data: {
+        hello: 'hello from data snackbar',
+      },
+    });
+    // this._snackBar.openFromComponent(PizzaPartyAnnotatedComponent, {
+    //   duration: this.durationInSeconds * 1000,
+    // });
+  }
 }

--- a/client/src/app/components/login/login.component.ts
+++ b/client/src/app/components/login/login.component.ts
@@ -15,7 +15,6 @@ export class LoginComponent {
   public username: string = '';
   public password: string = '';
   public isPasswordHidden: boolean = true;
-  durationInSeconds = 5;
 
   constructor(
     private router: Router,

--- a/client/src/app/services/api.service.ts
+++ b/client/src/app/services/api.service.ts
@@ -68,7 +68,13 @@ export class ApiService {
           resolve(res as ResponseInterface);
         },
         error: (err) => {
-          // Resolve if error:
+          // Resolve if error (and transform into ResponseInterface instead of HttpErrorResponse):
+          if (err.error) {
+            if (err.error.message) {
+              const newError = err.error;
+              resolve(newError);
+            }
+          }
           resolve(err);
         },
         complete: () => {

--- a/client/src/app/services/authentication.service.ts
+++ b/client/src/app/services/authentication.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@angular/core';
 import { ApiService } from './api.service';
 import { ResponseInterface } from '../interfaces/response.interface';
 import { Router } from '@angular/router';
+// import { SnackbarComponent } from '../shared/components/snackbar.component';
+// import { MatSnackBar } from '@angular/material/snack-bar';
+import { SnackbarService } from './snackbar.service';
 
 @Injectable({
   providedIn: 'root',
@@ -9,13 +12,27 @@ import { Router } from '@angular/router';
 export class AuthenticationService {
   private readonly route: string = '/authentication';
 
-  constructor(private apiService: ApiService, private router: Router) {}
+  constructor(
+    private apiService: ApiService,
+    private router: Router,
+    private snackbarService: SnackbarService // private _snackBar: MatSnackBar
+  ) {}
 
   public async attemptLogin(payload: {
     username: string;
     password: string;
   }): Promise<ResponseInterface> {
-    const response = await this.apiService.post(this.route, payload);
+    const response: ResponseInterface | any = await this.apiService.post(
+      this.route,
+      payload
+    );
+    if (response.error) {
+      let msg = response.message;
+      if (response.error.message) {
+        msg = response.error.message;
+      }
+      this.snackbarService.displayError(msg);
+    }
     return response;
   }
 
@@ -23,6 +40,7 @@ export class AuthenticationService {
     const response = await this.apiService.get(this.route + '/session');
     if (!response) {
       this.router.navigate(['/login']);
+      this.snackbarService.displayError('Session expired.');
     }
     return response;
   }
@@ -32,6 +50,7 @@ export class AuthenticationService {
     if (response === null) {
       // logout success
       this.router.navigate(['/login']);
+      this.snackbarService.displaySuccess('You have been logged out.');
     }
     return response;
   }

--- a/client/src/app/services/authentication.service.ts
+++ b/client/src/app/services/authentication.service.ts
@@ -13,23 +13,19 @@ export class AuthenticationService {
   constructor(
     private apiService: ApiService,
     private router: Router,
-    private snackbarService: SnackbarService // private _snackBar: MatSnackBar
+    private snackbarService: SnackbarService
   ) {}
 
   public async attemptLogin(payload: {
     username: string;
     password: string;
   }): Promise<ResponseInterface> {
-    const response: ResponseInterface | any = await this.apiService.post(
+    const response: ResponseInterface = await this.apiService.post(
       this.route,
       payload
     );
     if (response.error) {
-      let msg = response.message;
-      if (response.error.message) {
-        msg = response.error.message;
-      }
-      this.snackbarService.displayError(msg);
+      this.snackbarService.displayError(response.message);
     }
     return response;
   }

--- a/client/src/app/services/authentication.service.ts
+++ b/client/src/app/services/authentication.service.ts
@@ -2,8 +2,6 @@ import { Injectable } from '@angular/core';
 import { ApiService } from './api.service';
 import { ResponseInterface } from '../interfaces/response.interface';
 import { Router } from '@angular/router';
-// import { SnackbarComponent } from '../shared/components/snackbar.component';
-// import { MatSnackBar } from '@angular/material/snack-bar';
 import { SnackbarService } from './snackbar.service';
 
 @Injectable({

--- a/client/src/app/services/snackbar.service.ts
+++ b/client/src/app/services/snackbar.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@angular/core';
+import { SnackbarComponent } from '../shared/components/snackbar.component';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SnackbarService {
+  constructor(private _snackBar: MatSnackBar) {}
+
+  public displayError(message: string): void {
+    this._snackBar.openFromComponent(SnackbarComponent, {
+      horizontalPosition: 'right',
+      verticalPosition: 'top',
+      duration: 4000,
+      data: {
+        type: 'error',
+        message: message,
+        button: 'dismiss',
+      },
+    });
+  }
+
+  public displaySuccess(message: string): void {
+    this._snackBar.openFromComponent(SnackbarComponent, {
+      horizontalPosition: 'right',
+      verticalPosition: 'top',
+      duration: 4000,
+      data: {
+        type: 'success',
+        message: message,
+        button: 'dismiss',
+      },
+    });
+  }
+}

--- a/client/src/app/services/user.service.ts
+++ b/client/src/app/services/user.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ApiService } from './api.service';
 import { ResponseInterface } from '../interfaces/response.interface';
+import { SnackbarService } from './snackbar.service';
 
 @Injectable({
   providedIn: 'root',
@@ -8,18 +9,30 @@ import { ResponseInterface } from '../interfaces/response.interface';
 export class UserService {
   private readonly route: string = '/users';
 
-  constructor(private apiService: ApiService) {}
+  constructor(
+    private apiService: ApiService,
+    private snackbarService: SnackbarService
+  ) {}
 
   public async createUser(user: {
     username: string;
     password: string;
   }): Promise<ResponseInterface> {
-    const response = await this.apiService.post(this.route + '/create', user);
+    const response: ResponseInterface = await this.apiService.post(
+      this.route + '/create',
+      user
+    );
+    if (response.error) {
+      this.snackbarService.displayError(response.message);
+    }
     return response;
   }
 
   public async getAllUsers(): Promise<ResponseInterface> {
     const response = await this.apiService.get(this.route);
+    if (response.error) {
+      this.snackbarService.displayError(response.message);
+    }
     return response;
   }
 }

--- a/client/src/app/shared/components/snackbar.component.html
+++ b/client/src/app/shared/components/snackbar.component.html
@@ -1,0 +1,10 @@
+<span class="example-pizza-party" matSnackBarLabel> Pizza party!!! </span>
+<span matSnackBarActions>
+  <button
+    mat-button
+    matSnackBarAction
+    (click)="snackBarRef.dismissWithAction()"
+  >
+    🍕
+  </button>
+</span>

--- a/client/src/app/shared/components/snackbar.component.html
+++ b/client/src/app/shared/components/snackbar.component.html
@@ -1,10 +1,17 @@
-<span class="example-pizza-party" matSnackBarLabel> Pizza party!!! </span>
-<span matSnackBarActions>
-  <button
-    mat-button
-    matSnackBarAction
-    (click)="snackBarRef.dismissWithAction()"
-  >
-    🍕
-  </button>
-</span>
+<div class="snackbar-container" [ngClass]="data.type">
+  <span class="snackbar-type" matSnackBarLabel>
+    {{ data.type | titlecase }}
+  </span>
+  <span matSnackBarLabel> {{ data.message }} </span>
+  <span matSnackBarActions>
+    <button
+      mat-flat-button
+      color="warn"
+      [color]="data.type === 'error' ? 'warn' : 'primary'"
+      matSnackBarAction
+      (click)="snackBarRef.dismissWithAction()"
+    >
+      Dismiss
+    </button>
+  </span>
+</div>

--- a/client/src/app/shared/components/snackbar.component.scss
+++ b/client/src/app/shared/components/snackbar.component.scss
@@ -1,0 +1,28 @@
+.snackbar-container {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 15px 10px 15px;
+
+  &.error {
+    background-color: rgb(165, 52, 52);
+    color: #fff;
+  }
+
+  &.success {
+    background-color: #02835c;
+    color: #fff;
+  }
+
+  .snackbar-type {
+    font-size: 1.2rem;
+    font-weight: bold;
+  }
+
+  .mat-mdc-snack-bar-actions,
+  .mat-mdc-snack-bar-label {
+    padding: 5px 0 5px 0;
+    button.mat-mdc-snack-bar-action {
+      color: #fff;
+    }
+  }
+}

--- a/client/src/app/shared/components/snackbar.component.scss
+++ b/client/src/app/shared/components/snackbar.component.scss
@@ -9,7 +9,7 @@
   }
 
   &.success {
-    background-color: #02835c;
+    background-color: #04996c;
     color: #fff;
   }
 

--- a/client/src/app/shared/components/snackbar.component.ts
+++ b/client/src/app/shared/components/snackbar.component.ts
@@ -1,0 +1,39 @@
+import { Component, inject } from '@angular/core';
+import {
+  MatSnackBar,
+  MatSnackBarAction,
+  MatSnackBarActions,
+  MatSnackBarLabel,
+  MatSnackBarRef,
+} from '@angular/material/snack-bar';
+import { MatButtonModule } from '@angular/material/button';
+
+@Component({
+  selector: 'snackbar',
+  templateUrl: 'snackbar.component.html',
+  styles: [
+    `
+      :host {
+        display: flex;
+      }
+
+      .example-pizza-party {
+        color: hotpink;
+      }
+    `,
+  ],
+  standalone: true,
+  imports: [
+    MatButtonModule,
+    MatSnackBarLabel,
+    MatSnackBarActions,
+    MatSnackBarAction,
+  ],
+})
+export class PizzaPartyAnnotatedComponent {
+  snackBarRef = inject(MatSnackBarRef);
+
+  constructor() {
+    console.log(this.snackBarRef);
+  }
+}

--- a/client/src/app/shared/components/snackbar.component.ts
+++ b/client/src/app/shared/components/snackbar.component.ts
@@ -1,39 +1,30 @@
 import { Component, inject } from '@angular/core';
+import { SnackbarModules } from './snackbar.module';
 import {
-  MatSnackBar,
+  MAT_SNACK_BAR_DATA,
   MatSnackBarAction,
   MatSnackBarActions,
   MatSnackBarLabel,
   MatSnackBarRef,
 } from '@angular/material/snack-bar';
-import { MatButtonModule } from '@angular/material/button';
 
 @Component({
   selector: 'snackbar',
   templateUrl: 'snackbar.component.html',
-  styles: [
-    `
-      :host {
-        display: flex;
-      }
-
-      .example-pizza-party {
-        color: hotpink;
-      }
-    `,
-  ],
+  styleUrl: './snackbar.component.scss',
   standalone: true,
   imports: [
-    MatButtonModule,
+    SnackbarModules,
     MatSnackBarLabel,
     MatSnackBarActions,
     MatSnackBarAction,
   ],
 })
-export class PizzaPartyAnnotatedComponent {
+export class SnackbarComponent {
   snackBarRef = inject(MatSnackBarRef);
+  data = inject(MAT_SNACK_BAR_DATA);
 
   constructor() {
-    console.log(this.snackBarRef);
+    console.log(this.data);
   }
 }

--- a/client/src/app/shared/components/snackbar.module.ts
+++ b/client/src/app/shared/components/snackbar.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+
+export const SnackbarModules = [
+  CommonModule,
+  MatIconModule,
+  MatButtonModule,
+  MatSnackBarModule,
+];

--- a/client/src/styles/styles.scss
+++ b/client/src/styles/styles.scss
@@ -68,3 +68,7 @@ mat-card.mat-mdc-card {
     margin: 20px 0 20px 0;
   }
 }
+
+mat-snack-bar-container .mdc-snackbar__surface {
+  padding-right: 0;
+}


### PR DESCRIPTION
Added a service and component to handle generic snackbar notifications. I also refactored the client-side API service to transform HttpErrorResponse to our ResponseInterface data structure.